### PR TITLE
Upgrade marathon to 1.1.1

### DIFF
--- a/frameworks/marathon/spec.yml
+++ b/frameworks/marathon/spec.yml
@@ -1,6 +1,6 @@
 ---
 name: marathon
-version: 0.15.3
+version: 1.1.1
 license: ASL 2.0
 iteration: 1
 vendor: Mesosphere
@@ -15,7 +15,7 @@ depends:
 resources:
   - url: https://github.com/mesosphere/marathon/archive/v{{.Version}}.tar.gz
     hash-type: sha1
-    hash: d1fda04b58258e116b6ce8abaaa691c55622cc58
+    hash: 274e90f72a762cb5cdf4a9470da37448773781f8
   - url: https://dl.bintray.com/sbt/native-packages/sbt/0.13.9/sbt-0.13.9.tgz
     hash-type: sha1
     hash: 879ee72d049f1718a29551f55590aa94972f4c96


### PR DESCRIPTION
This needs to be tested against the Mesos 0.25 we are using in Mantl. 
