### PR TITLE
Mesos shouldn't on "devel" rpms

### DIFF
--- a/core/mesos/build.sh
+++ b/core/mesos/build.sh
@@ -5,7 +5,7 @@ echo `pwd`
 
 ## Dependencies
 sudo wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
-sudo yum install -y protobuf-devel protobuf-java protobuf-python boost-devel
+sudo yum install -y subversion-devel protobuf-devel protobuf-java protobuf-python boost-devel
 
 ## create an installation
 INSTALL={{.BuildRoot}}/out

--- a/core/mesos/spec.yml
+++ b/core/mesos/spec.yml
@@ -12,8 +12,8 @@ type: rpm
 depends:
   - cyrus-sasl
   - cyrus-sasl-md5
-  - subversion-devel
-  - protobuf-devel
+  - subversion-libs
+  - protobuf
 
 resources:
   - url: http://archive.apache.org/dist/mesos/{{.Version}}/mesos-{{.Version}}.tar.gz


### PR DESCRIPTION
subversion-devel and protobuf-devel are only build time dependencies, this causes us to install a lot of unneeded packages on production systems.
